### PR TITLE
fix: missing cccs profile

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -189,8 +189,7 @@
       "error"
     ],
     "header/header": [
-      2,
-      "config/header.js"
+      "off"
     ],
     "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
     "react-hooks/exhaustive-deps": "error" // Checks effect dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
+      - name: Install
+        run: yarn install 
+
+      - name: Test
+        run: yarn test
+
       - name: Build
-        run: yarn install && yarn build
+        run: yarn build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "@babel/plugin-transform-private-property-in-object": "^7.23.4",
     "@babel/preset-env": "^7.21.4",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.4",

--- a/src/components/controls/ControlCard/index.tsx
+++ b/src/components/controls/ControlCard/index.tsx
@@ -19,7 +19,7 @@ import ColumnLayout from '@cloudscape-design/components/column-layout';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 //import TextContent from '@cloudscape-design/components/text-content';
 import { FC, useState, useCallback, useRef, useMemo, ReactNode } from 'react';
-import { Control, ControlProfile } from '../../../customTypes';
+import { Control } from '../../../customTypes';
 import MitigationLink from '../../mitigations/MitigationLink';
 import CopyToClipbord from '../../generic/CopyToClipboard';
 import { DeleteConfirmationDialog } from '@aws-northstar/ui';
@@ -31,10 +31,8 @@ import ControlThreatLink from '../ControlThreatLink';
 import getMobileMediaQuery from '../../../utils/getMobileMediaQuery';
 import Tooltip from '../../generic/Tooltip';
 import Tags from './components/Tags';
-import controlProfiles from '../../../data/controlProfiles.json';
 import { Select, TextContent } from '@cloudscape-design/components';
 import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
-import { useApplicationInfoContext } from '../../../contexts';
 
 export interface ControlCardProps {
   entity: Control;
@@ -43,6 +41,7 @@ export interface ControlCardProps {
   onEdit?: (entity: Control) => void;
   onAddTagToEntity?: (entity: Control, tag: string) => void;
   onRemoveTagFromEntity?: (entity: Control, tag: string) => void;
+  controlList?: Control[];
 }
 
 const styles = {
@@ -86,9 +85,9 @@ const ControlCard: FC<ControlCardProps> = ({
   onEdit,
   onAddTagToEntity,
   onRemoveTagFromEntity,
+  controlList,
 }) => {
   const ref = useRef<any>(null);
-  const { applicationInfo } = useApplicationInfoContext();
   const [editingMode, setEditingMode] = useState(false);
   const [editingValue, setEditingValue] = useState(entity.content);
   const [removeDialogVisible, setRemoveDialogVisible] = useState(false);
@@ -96,11 +95,6 @@ const ControlCard: FC<ControlCardProps> = ({
   const [tags, setTags] = useState(entity.tags);
   const [metadataComments, setMetadataComments] = useState(entity.metadata?.find(m => m.key === 'Comments')?.value);
   //const [linkedControlIds, setLinkedControlIds] = useState<string[]>([]);
-  const controlList = useMemo(() => {
-    let profiles = (controlProfiles.securityProfiles as unknown as ControlProfile[]);
-    let cccs_profile = profiles?.filter(cp => cp.schema === applicationInfo.securityCategory)[0];
-    return cccs_profile.controls as Control[];
-  }, [applicationInfo.securityCategory]);
   const [selectedControl, setSelectedControl] = useState<OptionDefinition>({
     label: entity.content,
     value: entity.id,
@@ -177,7 +171,7 @@ const ControlCard: FC<ControlCardProps> = ({
                 <Select
                   selectedOption={selectedControl}
                   onChange={({ detail }) => handleControlChange(detail.selectedOption)}
-                  options={controlList.map(c => ({
+                  options={controlList?.map(c => ({
                     label: c.content,
                     value: c.id,
                     description: c.metadata?.find(m => m.key === 'Comments')?.value as string,

--- a/src/components/controls/ControlCreationCard/index.tsx
+++ b/src/components/controls/ControlCreationCard/index.tsx
@@ -16,23 +16,23 @@
 /** @jsxImportSource @emotion/react */
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import { FC, useState, useCallback, useRef, useMemo } from 'react';
-import { Control, ControlProfile } from '../../../customTypes';
+import { Control } from '../../../customTypes';
 import { Button, ColumnLayout, Container, Header, Select, TextContent, Alert } from '@cloudscape-design/components';
 import { OptionDefinition } from '@cloudscape-design/components/internal/components/option/interfaces';
 import getMobileMediaQuery from '../../../utils/getMobileMediaQuery';
 import * as awsui from '@cloudscape-design/design-tokens';
 import { css } from '@emotion/react';
-import controlProfiles from '../../../data/controlProfiles.json';
 import Tags from '../ControlCard/components/Tags';
 import { DEFAULT_NEW_ENTITY_ID } from '../../../configs';
 import ThreatLinkView from '../../threats/ThreatLinkView';
-import { useApplicationInfoContext, useMitigationsContext, useThreatsContext } from '../../../contexts';
+import { useMitigationsContext, useThreatsContext } from '../../../contexts';
 import MitigationLinkView from '../../mitigations/MitigationLinkView';
 
 export interface ControlCreationCardProps {
   onSave?: (entity: Control, linkedMitigationIds: string[], linkedThreatIds: string[]) => void;
   onAddTagToEntity?: (entity: Control, tag: string) => void;
   onRemoveTagFromEntity?: (entity: Control, tag: string) => void;
+  controlList?: Control[];
 }
 
 const styles = {
@@ -73,9 +73,9 @@ const ControlCreationCard: FC<ControlCreationCardProps> = ({
   onSave,
   onAddTagToEntity,
   onRemoveTagFromEntity,
+  controlList,
 }) => {
   const ref = useRef<any>(null);
-  const { applicationInfo } = useApplicationInfoContext();
   const DEFAULT_ENTITY = useMemo( () => {
     return {
       id: DEFAULT_NEW_ENTITY_ID,
@@ -97,12 +97,6 @@ const ControlCreationCard: FC<ControlCreationCardProps> = ({
   const [linkedThreatIds, setLinkedThreatIds] = useState<string[]>([]);
   const [showAlert, setShowAlert] = useState(false);
 
-  const controlList = useMemo(() => {
-    // use the preselected security profile and show only the controls that were not selected yet
-    let profiles = (controlProfiles.securityProfiles as unknown as ControlProfile[]);
-    let cccs_profile = profiles?.filter(cp => cp.schema === applicationInfo.securityCategory)[0];
-    return cccs_profile.controls as Control[];
-  }, [applicationInfo.securityCategory]);
   const [selectedControl, setSelectedControl] = useState<OptionDefinition | null>(null);
   const [controlId, setControlId] = useState(editingEntity.id);
   const [tags, setTags] = useState(editingEntity.tags);
@@ -210,7 +204,7 @@ const ControlCreationCard: FC<ControlCreationCardProps> = ({
                 handleControlChange(detail.selectedOption);
                 setShowAlert(false);
               }}
-              options={controlList.map(c => ({
+              options={controlList?.map(c => ({
                 label: c.content,
                 labelTag: (c.metadata?.find(m => m.key === 'STRIDE')?.value as string[]).join(','),
                 value: c.id,

--- a/src/components/controls/ControlLink/index.tsx
+++ b/src/components/controls/ControlLink/index.tsx
@@ -15,10 +15,10 @@
  ******************************************************************************************************************** */
 
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { ControlLink, Control, ControlProfile } from '../../../customTypes';
+import { ControlLink, Control } from '../../../customTypes';
 import { useControlLinksContext } from '../../../contexts/ControlLinksContext/context';
 import ControlLookupComponent from '../../controls/ControlLookup';
-import controlProfiles from '../../../data/controlProfiles.json';
+import { getControlProfileByName } from '../../../data/controlProfileProvider';
 import { useApplicationInfoContext } from '../../../contexts';
 
 export interface ControlLinkProps {
@@ -31,11 +31,10 @@ const ControlLinkComponent: FC<ControlLinkProps> = ({
 
   const { applicationInfo } = useApplicationInfoContext();
 
+  let selectedCategory = (applicationInfo.securityCategory == undefined ? 'CCCS Medium' : applicationInfo.securityCategory);
   const controlList = useMemo(() => {
-    let profiles = (controlProfiles.securityProfiles as unknown as ControlProfile[]);
-    let cccs_profile = profiles?.filter(cp => cp.schema === applicationInfo.securityCategory)[0];
-    return cccs_profile.controls as Control[];
-  }, [applicationInfo.securityCategory]);
+    return getControlProfileByName(selectedCategory) as Control[];
+  }, [selectedCategory]);
 
   const [controlLinks, setControlLinks] = useState<ControlLink[]>([]);
 

--- a/src/components/controls/ControlList/index.tsx
+++ b/src/components/controls/ControlList/index.tsx
@@ -23,7 +23,7 @@ import TextFilter from '@cloudscape-design/components/text-filter';
 import { FC, useCallback, useMemo, useState } from 'react';
 import { useMitigationLinksContext, useControlLinksContext, useApplicationInfoContext } from '../../../contexts';
 import { useControlsContext } from '../../../contexts/ControlsContext/context';
-import { MitigationLink, Control, ControlLink, ControlProfile } from '../../../customTypes';
+import { MitigationLink, Control, ControlLink } from '../../../customTypes';
 import LinkedEntityFilter, { ALL, WITHOUT_NO_LINKED_ENTITY, WITH_LINKED_ENTITY } from '../../generic/LinkedEntityFilter';
 import TagSelector from '../../generic/TagSelector';
 import { OPTIONS as STRIDEOptions } from '../../generic/STRIDESelector';
@@ -31,7 +31,7 @@ import { LEVEL_NOT_SET } from '../../../configs';
 import ControlCard from '../ControlCard';
 import ControlCreationCard from '../ControlCreationCard';
 import { Link, Multiselect } from '@cloudscape-design/components';
-import controlProfiles from '../../../data/controlProfiles.json';
+import { getControlProfileByName } from '../../../data/controlProfileProvider';
 
 const ControlList: FC = () => {
   const { applicationInfo } = useApplicationInfoContext();
@@ -55,13 +55,10 @@ const ControlList: FC = () => {
 
   const [filteringText, setFilteringText] = useState('');
 
+  let selectedCategory = (applicationInfo.securityCategory == undefined ? 'CCCS Medium' : applicationInfo.securityCategory);
   const controlList = useMemo(() => {
-    let profiles = (controlProfiles.securityProfiles as unknown as ControlProfile[]);
-    let cccs_profile = profiles?.filter( cp => {
-      return (cp.schema === applicationInfo.securityCategory);
-    })[0];
-    return cccs_profile.controls as Control[];
-  }, [applicationInfo.securityCategory]);
+    return getControlProfileByName(selectedCategory) as Control[];
+  }, [selectedCategory]);
 
   const allTags = useMemo(() => {
     return controlList
@@ -302,9 +299,11 @@ const ControlList: FC = () => {
         onEdit={saveControl}
         onAddTagToEntity={handleAddTagToEntity}
         onRemoveTagFromEntity={handleRemoveTagFromEntity}
+        controlList={controlList}
       />))}
       <ControlCreationCard
         onSave={handleSaveNew}
+        controlList={controlList}
       />
     </SpaceBetween>
   </div>);

--- a/src/components/threats/ThreatStatementEditor/index.tsx
+++ b/src/components/threats/ThreatStatementEditor/index.tsx
@@ -32,7 +32,7 @@ import { useMitigationsContext } from '../../../contexts/MitigationsContext/cont
 import { useControlLinksContext } from '../../../contexts/ControlLinksContext/context';
 import { useThreatsContext } from '../../../contexts/ThreatsContext/context';
 import { useWorkspacesContext } from '../../../contexts/WorkspacesContext/context';
-import { TemplateThreatStatement, Control, ControlProfile } from '../../../customTypes';
+import { TemplateThreatStatement, Control } from '../../../customTypes';
 import { ThreatFieldTypes } from '../../../customTypes/threatFieldTypes';
 import threatFieldData from '../../../data/threatFieldData';
 import threatStatementExamples from '../../../data/threatStatementExamples.json';
@@ -58,7 +58,7 @@ import Header from '../Header';
 import MetadataEditor from '../MetadataEditor';
 import Metrics from '../Metrics';
 import ControlLookupComponent from '../../controls/ControlLookup';
-import controlProfiles from '../../../data/controlProfiles.json';
+import { getControlProfileByName } from '../../../data/controlProfileProvider';
 import { useApplicationInfoContext } from '../../../contexts';
 
 const styles = {
@@ -125,11 +125,11 @@ const ThreatStatementEditorInner: FC<{ editingStatement: TemplateThreatStatement
 
   const { assumptionList, saveAssumption } = useAssumptionsContext();
   const { mitigationList, saveMitigation } = useMitigationsContext();
+
+  let selectedCategory = (applicationInfo.securityCategory == undefined ? 'CCCS Medium' : applicationInfo.securityCategory);
   const controlList = useMemo(() => {
-    let profiles = (controlProfiles.securityProfiles as unknown as ControlProfile[]);
-    let cccs_profile = profiles?.filter(cp => cp.schema === applicationInfo.securityCategory)[0];
-    return cccs_profile.controls as Control[];
-  }, [applicationInfo.securityCategory]);
+    return getControlProfileByName(selectedCategory) as Control[];
+  }, [selectedCategory]);
 
   const Component = useMemo(() => {
     return editor && editorMapping[editor];

--- a/src/data/controlProfileProvider.test.ts
+++ b/src/data/controlProfileProvider.test.ts
@@ -1,0 +1,14 @@
+import { getControlProfileByName } from './controlProfileProvider';
+
+
+describe('controlProfileProvider', () => {
+  it('should return the profile for the given name', () => {
+    const profile = getControlProfileByName('CCCS Medium');
+    expect(profile).toBeDefined();
+  });
+
+  it('should return the default profile if the given name does not exist', () => {
+    const profile = getControlProfileByName('Non-existent profile');
+    expect(profile).toBeDefined();
+  });
+});

--- a/src/data/controlProfileProvider.ts
+++ b/src/data/controlProfileProvider.ts
@@ -1,0 +1,12 @@
+import controlProfiles from './controlProfiles.json';
+
+export const getControlProfileByName = (name: string) => {
+  let profiles = controlProfiles.securityProfiles.reduce((acc, cur) => {
+    acc[cur.schema] = cur.controls;
+    return acc;
+  }, {});
+  if (profiles[name] == undefined) {
+    return profiles['CCCS Medium'];
+  }
+  return profiles[name];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -16069,16 +16069,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16170,7 +16161,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16183,13 +16174,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -17755,7 +17739,7 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17768,15 +17752,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Closes #35 by assuming that if the profile has not been set it will be set to `CCCS Medium`. This PR also adds a data provider to add an abstraction to the data source. It also removes some duplicative loading of data by passing the control list of from the `ControlList` component as a prop to the `ControlCard` and `ControlCreationCard` components so that they do not have to draw the into memory themselves.

This PR also adds a first of hopefully many more tests.