### PR TITLE
feat: ECR for PR review

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,41 @@
+resource "aws_ecr_repository" "threat_modeling_pr_review" {
+  name                 = "threat-modeling-pr-review"
+  image_tag_mutability = "MUTABLE"
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "website_staging_untagged" {
+  repository = aws_ecr_repository.threat_modeling_pr_review.name
+  policy = jsonencode({
+    "rules" : [
+      {
+        "rulePriority" : 1,
+        "description" : "Expire untagged images older than 14 days",
+        "selection" : {
+          "tagStatus" : "untagged",
+          "countType" : "sinceImagePushed",
+          "countUnit" : "days",
+          "countNumber" : 14
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      },
+      {
+        "rulePriority" : 2,
+        "description" : "Keep last 20 tagged images",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "tagPrefixList" : ["latest"],
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 20
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      }
+    ]
+  })
+}


### PR DESCRIPTION
This PR adds the ECR required to set up a PR review environment. The ECR will host the temporary docker images for the review lambdas. 