### PR TITLE
Fix zoom issue in Flow component, when the first node is added to the…

### DIFF
--- a/src/components/generic/Flow/index.tsx
+++ b/src/components/generic/Flow/index.tsx
@@ -123,7 +123,7 @@ function Flow() {
         }
         return node;
       }));
-  }, [selectedComponent, nodeDataValue, setNodes, setEdges, getZoom, zoomTo]);
+  }, [selectedComponent, nodeDataValue, setNodes, setEdges, getZoom, zoomTo, nodes.length]);
 
   const onNodesChange = useCallback(
     (changes) => {

--- a/src/components/generic/Flow/index.tsx
+++ b/src/components/generic/Flow/index.tsx
@@ -65,7 +65,7 @@ function Flow() {
   const { currentWorkspace } = useWorkspacesContext();
   const flowKey = `dataflow-diagram-${currentWorkspace?.id}`;
 
-  const { setViewport } = useReactFlow();
+  const { zoomTo, getZoom, setViewport } = useReactFlow();
 
   // Save and restore state
   const [rfInstance, setRfInstance] = useState<ReactFlowInstance<any, any> | null>(null);
@@ -101,6 +101,11 @@ function Flow() {
 
   useEffect(() => {
     if (!selectedComponent) {
+      // If this is the first node added to the flow, zoom out to prevent an implicit max zoom (of 4)
+      // this is probably another bug in react-flow that needs to be investigated and reported
+      if (nodes.length === 1 && getZoom() === 4) {
+        zoomTo(1);
+      }
       return;
     }
 
@@ -118,7 +123,7 @@ function Flow() {
         }
         return node;
       }));
-  }, [selectedComponent, nodeDataValue, setNodes, setEdges]);
+  }, [selectedComponent, nodeDataValue, setNodes, setEdges, getZoom, zoomTo]);
 
   const onNodesChange = useCallback(
     (changes) => {


### PR DESCRIPTION
When adding the first node to the flow, the diagram is automatically zooming in to its maximum predefined level (4), which is unexpected for a normal user experience. This actually seems to be another internal bug in the reactflow library, as I haven't seen this before while playing with the examples on the official reactflow web site. 

I've fixed by setting back the zoom to level 1, when and only when the first node is being added to the flow.