### PR TITLE
fix: setSelectedComponent to null on remove event

### DIFF
--- a/src/components/generic/Flow/index.tsx
+++ b/src/components/generic/Flow/index.tsx
@@ -132,7 +132,7 @@ function Flow() {
     (changes) => {
       setNodeDataValue({});
       setNodes((oldNodes) => applyNodeChanges(changes, oldNodes));
-      for (let selection of changes.filter(c => c.type === 'select' || (c.type === 'position' && c.dragging === false))) {
+      for (let selection of changes.filter(c => c.type === 'select' || (c.type === 'position' && c.dragging === false) || c.type ==='remove')) {
         if (selection.selected || selection.dragging === false) {
           setSelectedComponent(nodes.find((node) => node.id === selection.id) as Node | null);
         } else {


### PR DESCRIPTION
Closes #64 by setting `setSelectedComponent` to null on the `remove` event.