### PR TITLE
feat: add Z-index changer for DFD

### DIFF
--- a/src/components/generic/Flow/Nodes/ZIndexChanger.test.tsx
+++ b/src/components/generic/Flow/Nodes/ZIndexChanger.test.tsx
@@ -1,0 +1,32 @@
+import { render, fireEvent } from '@testing-library/react';
+import ZIndexChanger from './ZIndexChanger';
+
+describe('ZIndexChanger', () => {
+it('should call the addCallback function with "first" when DoubleArrowUpIcon is clicked', () => {
+    const addCallback = jest.fn();
+    const { getByRole } = render(<ZIndexChanger addCallback={addCallback} />);
+    fireEvent.click(getByRole('button', {name: 'double-arrow-up-icon'}));
+    expect(addCallback).toHaveBeenCalledWith('first');
+});
+
+it('should call the addCallback function with "up" when ArrowUpIcon is clicked', () => {
+    const addCallback = jest.fn();
+    const { getByRole } = render(<ZIndexChanger addCallback={addCallback} />);
+    fireEvent.click(getByRole('button', {name: 'arrow-up-icon'}));
+    expect(addCallback).toHaveBeenCalledWith('up');
+});
+
+  it('should call the addCallback function with "down" when ArrowDownIcon is clicked', () => {
+    const addCallback = jest.fn();
+    const { getByRole } = render(<ZIndexChanger addCallback={addCallback} />);
+    fireEvent.click(getByRole('button', {name: 'arrow-down-icon'}));
+    expect(addCallback).toHaveBeenCalledWith('down');
+  });
+
+  it('should call the addCallback function with "last" when DoubleArrowDownIcon is clicked', () => {
+    const addCallback = jest.fn();
+    const { getByRole } = render(<ZIndexChanger addCallback={addCallback} />);
+    fireEvent.click(getByRole('button', {name: 'double-arrow-down-icon'}));
+    expect(addCallback).toHaveBeenCalledWith('last');
+  });
+});

--- a/src/components/generic/Flow/Nodes/ZIndexChanger.tsx
+++ b/src/components/generic/Flow/Nodes/ZIndexChanger.tsx
@@ -1,0 +1,24 @@
+import { memo } from 'react';
+import { DoubleArrowUpIcon, ArrowUpIcon, ArrowDownIcon, DoubleArrowDownIcon } from '@radix-ui/react-icons';
+
+import styled from '@emotion/styled';
+
+type ZIndexChangerProps = {
+  addCallback?: (string) => void;
+};
+
+const ZIndexChangerStyle = styled.div`
+    border: 1px dashed #000;
+    padding: 5px;
+`;
+
+export default memo(({ addCallback }: ZIndexChangerProps) => {
+  return (
+    <ZIndexChangerStyle>
+      <DoubleArrowUpIcon role='button' aria-label='double-arrow-up-icon' onClick={() => addCallback && addCallback('first')}/>
+      <ArrowUpIcon role='button' aria-label='arrow-up-icon' onClick={() => addCallback && addCallback('up')}/>
+      <ArrowDownIcon role='button' aria-label='arrow-down-icon' onClick={() => addCallback && addCallback('down')}/>
+      <DoubleArrowDownIcon role='button' aria-label='double-arrow-down-icon' onClick={() => addCallback && addCallback('last')}/>
+    </ZIndexChangerStyle>
+  );
+});

--- a/src/components/generic/Flow/index.tsx
+++ b/src/components/generic/Flow/index.tsx
@@ -207,7 +207,7 @@ function Flow() {
         position: { x, y },
       };
       setSaveState(false);
-      return (type === 'trustBoundary' ? [newNode, ...nds] : [...nds, newNode]);
+      return [...nds, newNode];
     });
   }, [setNodes]);
 

--- a/src/components/generic/Flow/index.tsx
+++ b/src/components/generic/Flow/index.tsx
@@ -32,6 +32,7 @@ import BiDirectionalEdge from './Edges/BiDirectionalEdge';
 
 import PropertiesPanel from './Properties/PropertiesPanel';
 import SaveButton from './SaveButton/SaveButton';
+import ZIndexChanger from './Nodes/ZIndexChanger';
 
 import ThreatList from './Threats/ThreatList';
 
@@ -210,6 +211,21 @@ function Flow() {
     });
   }, [setNodes]);
 
+  const onZIndexChange = useCallback((direction: string) => {
+    setNodes((nds) => {
+      const selectedNode = nds.find((node) => node.id === selectedComponent?.id);
+      if (!selectedNode) {
+        return nds;
+      }
+      const index = nds.indexOf(selectedNode);
+      const newIndex = direction === 'last' ? 0 : direction === 'down' ? index - 1 : direction === 'up' ? index + 1 : nds.length - 1;
+      const node = nds.splice(index, 1)[0];
+      nds.splice(newIndex, 0, node);
+      setSaveState(false);
+      return [...nds];
+    });
+  }, [setNodes, selectedComponent]);
+
   // Threats state
   const { statementList } = useThreatsContext();
   const [threatList, setThreatList] = useState(statementList);
@@ -249,6 +265,7 @@ function Flow() {
             <Background />
             <Controls />
             <Panel position="top-left"><NodeSelector addCallback={onAdd} /></Panel>
+            <Panel position="top-right"><ZIndexChanger addCallback={onZIndexChange} /></Panel>
           </ReactFlow>
         </s.OuterContainer>
       </Container>


### PR DESCRIPTION
Closes #69 by adding the ability to change the z-order of elements in the data flow diagram using four buttons (first, up, down, last)

![image](https://github.com/cds-snc/threat-modeling-tool/assets/867334/052ffbc9-3090-4424-b22e-ef8638a947e4)
