### PR TITLE
Feat/hook flow into context

### DIFF
--- a/src/components/FullAppLayout/index.tsx
+++ b/src/components/FullAppLayout/index.tsx
@@ -120,6 +120,7 @@ const AppLayout: FC<PropsWithChildren<AppLayoutProps>> = ({
       (e) => {
         if (!e.detail.external) {
           e.preventDefault();
+          e.stopPropagation();
           setContentType(undefined);
           navigate(e.detail.href);
         }

--- a/src/components/diagram/DiagramInfo/index.tsx
+++ b/src/components/diagram/DiagramInfo/index.tsx
@@ -9,7 +9,6 @@ const DiagramInfo: FC<EditableComponentBaseProps> = () => {
       <Flow />
     </ReactFlowProvider>
   );
-
 };
 
 export default DiagramInfo;

--- a/src/components/generic/Flow/index.tsx
+++ b/src/components/generic/Flow/index.tsx
@@ -67,6 +67,8 @@ function Flow() {
   // Save and restore state
   const [rfInstance, setRfInstance] = useState<ReactFlowInstance<any, any> | null>(null);
   const [saveState, setSaveState] = useState(true);
+  const [nodes, setNodes] = useNodesState([]);
+  const [edges, setEdges] = useEdgesState([]);
 
   const { flow, setFlow } = useFlowContext();
 
@@ -77,7 +79,7 @@ function Flow() {
     }
   }, [rfInstance, setFlow]);
 
-  const restoreFlow = async () => {
+  const restoreFlow = useCallback(async () => {
     if (flow.content) {
       const diagram = JSON.parse(flow.content || '{}');
       const { x = 0, y = 0, zoom = 1 } = diagram.viewport;
@@ -85,7 +87,11 @@ function Flow() {
       setEdges(diagram.edges || []);
       setViewport({ x, y, zoom });
     }
-  };
+  }, [flow.content, setNodes, setEdges, setViewport]);
+
+  useEffect(() => {
+    restoreFlow().catch(console.error);
+  }, [flow.content, restoreFlow]);
 
   const onInit = async (instance) => {
     setRfInstance(instance);
@@ -93,9 +99,6 @@ function Flow() {
   };
 
   // Nodes and edges state
-  const [nodes, setNodes] = useNodesState([]);
-  const [edges, setEdges] = useEdgesState([]);
-
   const [nodeDataValue, setNodeDataValue] = useState({});
   const [selectedComponent, setSelectedComponent] = useState<Node | Edge | null>(null);
 

--- a/src/configs/localStorageKeys.ts
+++ b/src/configs/localStorageKeys.ts
@@ -34,6 +34,7 @@ export const LOCAL_STORAGE_KEY_APPLICATION_INFO = 'ThreatStatementGenerator.Appl
 export const LOCAL_STORAGE_KEY_ARCHIECTURE_INFO = 'ThreatStatementGenerator.ArchitectureInfo';
 export const LOCAL_STORAGE_KEY_DATAFLOW_INFO = 'ThreatStatementGenerator.DataflowInfo';
 export const LOCAL_STORAGE_KEY_DIAGRAM_INFO = 'ThreatStatementGenerator.DiagramInfo';
+export const LOCAL_STORAGE_KEY_FLOW_INFO = 'ThreatStatementGenerator.FlowInfo';
 
 export const LOCAL_STORAGE_KEY_WORKSPACE_LIST_MIGRATION = 'ThreatStatementGenerator.workspaceListMigration';
 export const LOCAL_STORAGE_KEY_THREATS_LIST_MIGRATION = 'ThreatStatementGenerator.threatListMigration';

--- a/src/contexts/FlowContext/components/LocalStateContextProvider/index.tsx
+++ b/src/contexts/FlowContext/components/LocalStateContextProvider/index.tsx
@@ -1,0 +1,34 @@
+import { FC, PropsWithChildren, useCallback, useState } from 'react';
+import { Flow } from '../../../../customTypes';
+import { FLOW_DEFAULT_VALUE } from '../../../constants';
+import { LocalStateContextProviderBaseProps } from '../../../types';
+import { FlowContext } from '../../context';
+import { FlowContextProviderProps } from '../../types';
+
+const FlowLocalStateContextProvider: FC<
+PropsWithChildren<FlowContextProviderProps & LocalStateContextProviderBaseProps<Flow>>> = ({
+  children,
+  initialValue,
+}) => {
+  const [flow, setFlow] = useState<Flow>(initialValue || FLOW_DEFAULT_VALUE);
+
+  const handleRemoveFlow = useCallback(async () => {
+    setFlow(FLOW_DEFAULT_VALUE);
+  }, []);
+
+  const handleDeleteWorkspace = useCallback(async (_workspaceId: string) => {
+    setFlow(FLOW_DEFAULT_VALUE);
+  }, []);
+
+  return (<FlowContext.Provider value={{
+    flow,
+    setFlow,
+    removeFlow: handleRemoveFlow,
+    onDeleteWorkspace: handleDeleteWorkspace,
+  }}>
+    {children}
+  </FlowContext.Provider>);
+};
+
+export default FlowLocalStateContextProvider;
+

--- a/src/contexts/FlowContext/components/LocalStorageContextProvider/index.tsx
+++ b/src/contexts/FlowContext/components/LocalStorageContextProvider/index.tsx
@@ -1,0 +1,48 @@
+import { FC, PropsWithChildren, useCallback } from 'react';
+import useLocalStorageState from 'use-local-storage-state';
+import { LOCAL_STORAGE_KEY_FLOW_INFO } from '../../../../configs/localStorageKeys';
+import { Flow } from '../../../../customTypes';
+import removeLocalStorageKey from '../../../../utils/removeLocalStorageKey';
+import { FLOW_DEFAULT_VALUE } from '../../../constants';
+import { FlowContext } from '../../context';
+import { FlowContextProviderProps } from '../../types';
+
+const getLocalStorageKey = (workspaceId: string | null) => {
+  if (workspaceId) {
+    return `${LOCAL_STORAGE_KEY_FLOW_INFO}_${workspaceId}`;
+  }
+
+  return LOCAL_STORAGE_KEY_FLOW_INFO;
+};
+
+const FlowLocalStorageContextProvider: FC<PropsWithChildren<FlowContextProviderProps>> = ({
+  children,
+  workspaceId: currentWorkspaceId,
+}) => {
+  const [flow, setFlow, { removeItem }] = useLocalStorageState<Flow>(getLocalStorageKey(currentWorkspaceId), {
+    defaultValue: FLOW_DEFAULT_VALUE,
+  });
+
+  const handleRemoveFlow = useCallback(async () => {
+    removeItem();
+  }, [removeItem]);
+
+  const handleDeleteWorkspace = useCallback(async (workspaceId: string) => {
+    window.setTimeout(() => {
+      // to delete after the workspace is switched. Otherwise the default value is set again.
+      removeLocalStorageKey(getLocalStorageKey(workspaceId));
+    }, 1000);
+  }, []);
+
+  return (<FlowContext.Provider value={{
+    flow,
+    setFlow,
+    removeFlow: handleRemoveFlow,
+    onDeleteWorkspace: handleDeleteWorkspace,
+  }}>
+    {children}
+  </FlowContext.Provider>);
+};
+
+export default FlowLocalStorageContextProvider;
+

--- a/src/contexts/FlowContext/context.ts
+++ b/src/contexts/FlowContext/context.ts
@@ -1,0 +1,22 @@
+import { useContext, createContext } from 'react';
+import { Flow } from '../../customTypes';
+
+export interface FlowContextApi {
+  flow: Flow;
+  setFlow: React.Dispatch<React.SetStateAction<Flow>>;
+  removeFlow: () => Promise<void>;
+  onDeleteWorkspace: (workspaceId: string) => Promise<void>;
+}
+
+const initialState: FlowContextApi = {
+  flow: {
+    content: '',
+  },
+  setFlow: () => { },
+  removeFlow: () => Promise.resolve(),
+  onDeleteWorkspace: () => Promise.resolve(),
+};
+
+export const FlowContext = createContext<FlowContextApi>(initialState);
+
+export const useFlowContext = () => useContext(FlowContext);

--- a/src/contexts/FlowContext/index.tsx
+++ b/src/contexts/FlowContext/index.tsx
@@ -1,0 +1,14 @@
+import { FC, PropsWithChildren } from 'react';
+import FlowLocalStorageContextProvider from './components/LocalStorageContextProvider';
+import { useFlowContext } from './context';
+import { FlowContextProviderProps } from './types';
+
+const FlowContextProvider: FC<PropsWithChildren<FlowContextProviderProps>> = (props) => {
+  return (<FlowLocalStorageContextProvider {...props} />);
+};
+
+export default FlowContextProvider;
+
+export {
+  useFlowContext,
+};

--- a/src/contexts/FlowContext/types.ts
+++ b/src/contexts/FlowContext/types.ts
@@ -1,0 +1,4 @@
+import { ContextProviderBaseProps } from '../types';
+
+export interface FlowContextProviderProps extends ContextProviderBaseProps {
+}

--- a/src/contexts/WorkspaceContextAggregator/index.tsx
+++ b/src/contexts/WorkspaceContextAggregator/index.tsx
@@ -21,6 +21,7 @@ import ArchitectureInfoContextProvider from '../ArchitectureContext';
 import AssumptionLinksContextProvider from '../AssumptionLinksContext';
 import AssumptionsContextProvider from '../AssumptionsContext';
 import DataflowInfoContextProvider from '../DataflowContext';
+import FlowContextProvider from '../FlowContext';
 import ExampleContextProvider from '../ExampleContext';
 import GlobalSetupContextProvider from '../GlobalSetupContext';
 import MitigationLinksContextProvider from '../MitigationLinksContext';
@@ -58,7 +59,9 @@ const WorkspaceContextInnerAggregator: FC<PropsWithChildren<WorkspaceContextAggr
                       <ApplicationInfoContextProvider workspaceId={workspaceId}>
                         <ArchitectureInfoContextProvider workspaceId={workspaceId}>
                           <DataflowInfoContextProvider workspaceId={workspaceId}>
-                            {children}
+                            <FlowContextProvider workspaceId={workspaceId}>
+                              {children}
+                            </FlowContextProvider>
                           </DataflowInfoContextProvider>
                         </ArchitectureInfoContextProvider>
                       </ApplicationInfoContextProvider>

--- a/src/contexts/constants.ts
+++ b/src/contexts/constants.ts
@@ -14,6 +14,10 @@
   limitations under the License.
  ******************************************************************************************************************** */
 
+export const FLOW_DEFAULT_VALUE = {
+  content: '',
+};
+
 export const INFO_DEFAULT_VALUE = {
   description: '',
 };

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -26,6 +26,8 @@ export { default as DataflowInfoContext } from './DataflowContext';
 export { useDataflowInfoContext } from './DataflowContext/context';
 export { default as DiagramInfoContext } from './DiagramContext';
 export { useDiagramInfoContext } from './DiagramContext/context';
+export { default as FlowContext } from './FlowContext';
+export { useFlowContext } from './FlowContext/context';
 export { default as GlobalSetupContext } from './GlobalSetupContext';
 export { useGlobalSetupContext } from './GlobalSetupContext/context';
 export { default as ControlLinksContext } from './ControlLinksContext';

--- a/src/customTypes/flow.ts
+++ b/src/customTypes/flow.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const FlowSchema = z.object({
+  content: z.string().optional(),
+}).strict();
+
+export type Flow = z.infer<typeof FlowSchema>;

--- a/src/customTypes/index.ts
+++ b/src/customTypes/index.ts
@@ -30,3 +30,4 @@ export * from './diagram';
 export * from './dataExchange';
 export * from './events';
 export * from './components';
+export * from './flow';

--- a/src/hooks/useHasContent/index.tsx
+++ b/src/hooks/useHasContent/index.tsx
@@ -20,12 +20,13 @@ import { useArchitectureInfoContext } from '../../contexts/ArchitectureContext';
 import { useAssumptionsContext } from '../../contexts/AssumptionsContext';
 import { useDataflowInfoContext } from '../../contexts/DataflowContext';
 import { useDiagramInfoContext } from '../../contexts/DiagramContext';
+import { useFlowContext } from '../../contexts/FlowContext';
 import { useMitigationsContext } from '../../contexts/MitigationsContext';
 import { useControlsContext } from '../../contexts/ControlsContext';
 import { useControlProfilesContext } from '../../contexts/ControlProfilesContext';
 import { useThreatsContext } from '../../contexts/ThreatsContext';
 import { HasContentDetails } from '../../customTypes';
-import { hasApplicationName, hasApplicationInfo, hasArchitectureInfo, hasAssumptions, hasDiagramInfo, hasDataflowInfo, hasMitigations, hasControls, hasControlProfiles, hasThreats } from '../../utils/hasContent';
+import { hasApplicationName, hasApplicationInfo, hasArchitectureInfo, hasAssumptions, hasDiagramInfo, hasDataflowInfo, hasMitigations, hasControls, hasControlProfiles, hasThreats, hasFlow } from '../../utils/hasContent';
 
 
 const useHasContent = () => {
@@ -33,19 +34,21 @@ const useHasContent = () => {
   const { architectureInfo } = useArchitectureInfoContext();
   const { diagramInfo } = useDiagramInfoContext();
   const { dataflowInfo } = useDataflowInfoContext();
+  const { flow } = useFlowContext();
   const { assumptionList } = useAssumptionsContext();
   const { controlList } = useControlsContext();
   const { controlProfileList } = useControlProfilesContext();
   const { mitigationList } = useMitigationsContext();
   const { statementList } = useThreatsContext();
 
-  const hasContent: [ boolean, HasContentDetails] = useMemo(() => {
+  const hasContent: [boolean, HasContentDetails] = useMemo(() => {
     const details = {
       applicationName: hasApplicationName(applicationInfo),
       applicationInfo: hasApplicationInfo(applicationInfo),
       architecture: hasArchitectureInfo(architectureInfo),
       diagram: hasDiagramInfo(diagramInfo),
       dataflow: hasDataflowInfo(dataflowInfo),
+      flow: hasFlow(flow),
       assumptions: hasAssumptions(assumptionList),
       controls: hasControls(controlList),
       controlProfiles: hasControlProfiles(controlProfileList),
@@ -56,7 +59,18 @@ const useHasContent = () => {
     const sum = Object.values(details).some(x => x);
 
     return [sum, details];
-  }, [applicationInfo, architectureInfo, dataflowInfo, assumptionList, mitigationList, controlList, controlProfileList, statementList, diagramInfo]);
+  }, [
+    applicationInfo,
+    architectureInfo,
+    dataflowInfo,
+    assumptionList,
+    mitigationList,
+    controlList,
+    controlProfileList,
+    statementList,
+    diagramInfo,
+    flow,
+  ]);
 
   return hasContent;
 };

--- a/src/hooks/useRemoveData/index.ts
+++ b/src/hooks/useRemoveData/index.ts
@@ -25,6 +25,9 @@ import { useGlobalSetupContext } from '../../contexts/GlobalSetupContext';
 import { useMitigationLinksContext } from '../../contexts/MitigationLinksContext';
 import { useMitigationsContext } from '../../contexts/MitigationsContext';
 import { useThreatsContext } from '../../contexts/ThreatsContext';
+import { useFlowContext } from '../../contexts/FlowContext';
+import { useControlsContext } from '../../contexts/ControlsContext';
+import { useControlLinksContext } from '../../contexts/ControlLinksContext';
 
 const useRemoveData = () => {
   const { composerMode } = useGlobalSetupContext();
@@ -37,6 +40,9 @@ const useRemoveData = () => {
   const { removeAllStatements, onDeleteWorkspace: threatsDeleteWorkspace } = useThreatsContext();
   const { removeAllAssumptionLinks, onDeleteWorkspace: assumptionLinksDeleteWorkspace } = useAssumptionLinksContext();
   const { removeAllMitigationLinks, onDeleteWorkspace: mitigationLinksDeleteWorkspace } = useMitigationLinksContext();
+  const { removeFlow, onDeleteWorkspace: flowDeleteWorkspace } = useFlowContext();
+  const { removeAllControls, onDeleteWorkspace: controlsDeleteWorkspace } = useControlsContext();
+  const { removeAllControlLinks, onDeleteWorkspace: controlLinksDeleteWorkspace } = useControlLinksContext();
 
   const removeData = useCallback(async () => {
     if (composerMode === 'Full') {
@@ -49,6 +55,9 @@ const useRemoveData = () => {
         removeAllStatements(),
         removeAllAssumptionLinks(),
         removeAllMitigationLinks(),
+        removeFlow(),
+        removeAllControls(),
+        removeAllControlLinks(),
       ]);
     }
 
@@ -57,7 +66,7 @@ const useRemoveData = () => {
     removeApplicationInfo, removeArchitectureInfo, removeDataflowInfo,
     removeAllAssumptions, removeAllMitigations,
     removeAllStatements, removeAllAssumptionLinks,
-    removeAllMitigationLinks]);
+    removeAllMitigationLinks, removeFlow, removeAllControls, removeAllControlLinks]);
 
   const deleteCurrentWorkspace = useCallback(async (toDeleteWorkspaceId: string) => {
     if (toDeleteWorkspaceId) {
@@ -71,6 +80,9 @@ const useRemoveData = () => {
         mitigationsDeleteWorkspace(toDeleteWorkspaceId),
         assumptionLinksDeleteWorkspace(toDeleteWorkspaceId),
         mitigationLinksDeleteWorkspace(toDeleteWorkspaceId),
+        flowDeleteWorkspace(toDeleteWorkspaceId),
+        controlsDeleteWorkspace(toDeleteWorkspaceId),
+        controlLinksDeleteWorkspace(toDeleteWorkspaceId),
       ]);
 
       switchWorkspace(null);
@@ -85,6 +97,9 @@ const useRemoveData = () => {
     mitigationsDeleteWorkspace,
     assumptionLinksDeleteWorkspace,
     mitigationLinksDeleteWorkspace,
+    flowDeleteWorkspace,
+    controlsDeleteWorkspace,
+    controlLinksDeleteWorkspace,
     removeWorkspace,
   ]);
 

--- a/src/utils/hasContent/index.ts
+++ b/src/utils/hasContent/index.ts
@@ -14,7 +14,7 @@
   limitations under the License.
  ******************************************************************************************************************** */
 
-import { ApplicationInfo, ArchitectureInfo, Assumption, DiagramInfo, DataflowInfo, Mitigation, Control, TemplateThreatStatement, ControlProfile } from '../../customTypes';
+import { ApplicationInfo, ArchitectureInfo, Assumption, DiagramInfo, DataflowInfo, Mitigation, Control, TemplateThreatStatement, ControlProfile, Flow } from '../../customTypes';
 
 export const hasApplicationName = (applicationInfo: ApplicationInfo) => {
   return !!(applicationInfo.name);
@@ -54,4 +54,8 @@ export const hasControls = (controls: Control[]) => {
 
 export const hasControlProfiles = (controlProfiles: ControlProfile[]) => {
   return controlProfiles.length > 0;
+};
+
+export const hasFlow = (flow: Flow) => {
+  return !!(flow.content);
 };


### PR DESCRIPTION
Closes #76 by giving Flow diagrams their own context provider that manages storage in localStorage with the appropriate workspace ID.